### PR TITLE
[Docs] Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, and GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- macOS version:
+- Python version:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem?**
+A clear description of what the problem is.
+
+**Describe the solution you'd like**
+What you want to happen.
+
+**Describe alternatives you've considered**
+Any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+<!-- What does this PR do? -->
+
+## Related Issue
+<!-- Link to the issue this PR addresses -->
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Refactor
+- [ ] Other
+
+## Testing
+<!-- How was this tested? -->
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Self-reviewed my code
+- [ ] Updated documentation if needed
+- [ ] Added tests if applicable

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery
+* Trolling, insulting or derogatory comments
+* Public or private harassment
+* Publishing others' private information without permission
+* Other conduct inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise inappropriate behavior may be reported to community leaders. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to ihealth-relay
+
+Thank you for your interest in contributing to ihealth-relay!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/your-username/ihealth-relay.git`
+3. Create a branch: `git checkout -b my-feature`
+4. Make your changes
+5. Submit a pull request
+
+## Development Setup
+
+- macOS with Python 3.10+ (uses only standard library)
+- No external dependencies required
+- Run tests locally before submitting
+
+## Pull Request Guidelines
+
+- Keep changes focused and small
+- Update documentation if needed
+- Describe what your PR does and why in the description
+
+## Code Style
+
+- Follow PEP 8 for Python code
+- Use descriptive variable names
+- Add comments for complex logic
+
+## Reporting Issues
+
+- Use the issue tracker to report bugs or request features
+- Include steps to reproduce for bug reports
+- Specify your macOS and Python versions
+
+## Need Help?
+
+Open an issue with your question and we'll help you get started.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+The latest released version receives security updates.
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by opening a GitHub issue or contacting the maintainers directly.
+
+- Do not disclose publicly until a fix is available
+- Include detailed reproduction steps
+- We will acknowledge receipt and work on a fix promptly
+
+## Data Handling
+
+ihealth-relay processes Apple Health data locally. No health data is transmitted to third parties unless explicitly configured by the user (e.g., Notion sink).


### PR DESCRIPTION
## Summary

Adds standard open-source project files as requested in arkatom/ihealth-relay#6.

## Changes

- `CONTRIBUTING.md` — development setup, PR guidelines, code style
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1
- `SECURITY.md` — security policy and data handling info
- `.github/ISSUE_TEMPLATE/bug_report.md` — bug report template
- `.github/ISSUE_TEMPLATE/feature_request.md` — feature request template
- `.github/pull_request_template.md` — PR template

Closes arkatom/ihealth-relay#6